### PR TITLE
Substitute MetaCentrum docs by a link to external pages only.

### DIFF
--- a/main/compute/grid/index.md
+++ b/main/compute/grid/index.md
@@ -1,0 +1,8 @@
+---
+hide:
+  - toc
+---
+
+# e-INFRA CZ Grid Computing
+
+Metacentrum Grid documentation is currently located at [https://docs.metacentrum.cz](https://docs.metacentrum.cz)

--- a/main/compute/index.md
+++ b/main/compute/index.md
@@ -26,9 +26,7 @@ e-INFRA CZ provides a wide range of computational services for the scientific co
 
     Traditional distributed computing with software and queues.
 
-    [:octicons-arrow-right-24: How to start](./grid/access/)   
-    [:octicons-arrow-right-24: Running first job](./grid/computing/run-basic-job/)   
-    [:octicons-arrow-right-24: More](./grid/computing/)   
+    [:octicons-arrow-right-24: Documentation](https://docs.metacentrum.cz)   
 
 -   :fontawesome-solid-atom:{ .md .middle } __Supercomputing__
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ nav:
   - Data processing:
     - compute/index.md
     - Concepts: '!include ./topics/compute/concepts/mkdocs.yml'
-    - MetaCentrum Grid: '!include ./topics/compute/grid/mkdocs.yml'
+    - MetaCentrum Grid: compute/grid/index.md
     - Supercomputer: '!include ./topics/compute/supercomputing/mkdocs.yml'
     - Kubernetes: '!include ./topics/compute/kubernetes/mkdocs.yml'
     - OpenStack: '!include ./topics/compute/openstack/mkdocs.yml'


### PR DESCRIPTION
MetaCentrum docs has been transferred to fumadocs technology.

It cannot be simply included as a mkdocs submodule now.

Therefore substitute mentions of MetaCentrum docs by a link to
docs.metacentrum.cz untill it is integrated in another way.
